### PR TITLE
Fix the issue caused by change of default empty public key

### DIFF
--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -285,7 +285,7 @@ export default {
   },
 
   created: function () {
-    if (this.$store.state.keys.pub !== '00') {
+    if (this.$store.state.keys.pub !== '00000000000000000000000000') {
       this.$store.dispatch('launch')
       this.initializeKeys = false
     }


### PR DESCRIPTION
- The default empty user public key was recently modified, and this makes the UI fail to recognize new or reset local storage.
- Commit: https://github.com/fiatjaf/branle/commit/0064b46105c5c9f6f0c2820e09d242058d8ccc7d