### PR TITLE
feat: add syntax highlighting for MD

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "core-js": "^3.6.5",
     "identicon.js": "^2.3.3",
     "markdown-it": "^12.3.0",
+    "markdown-it-highlightjs": "^3.6.0",
     "nostr-tools": "^0.20.1",
     "pouchdb-adapter-idb": "6",
     "pouchdb-core": "6",

--- a/quasar.conf.js
+++ b/quasar.conf.js
@@ -27,7 +27,7 @@ module.exports = configure(function (ctx) {
     boot: ['global-components'],
 
     // https://quasar.dev/quasar-cli/quasar-conf-js#Property%3A-css
-    css: ['add-tailwind.css'],
+    css: ['add-tailwind.css', '../../node_modules/highlight.js/styles/base16/solarized-light.css'],
 
     // https://github.com/quasarframework/quasar/tree/dev/extras
     extras: [

--- a/src/components/Markdown.vue
+++ b/src/components/Markdown.vue
@@ -6,6 +6,7 @@
 
 <script>
 import MarkdownIt from 'markdown-it'
+import markdownHighlightJs from 'markdown-it-highlightjs'
 
 import helpersMixin from '../utils/mixin'
 
@@ -14,6 +15,9 @@ const md = MarkdownIt({
   breaks: true,
   linkify: true
 })
+md
+  .use(markdownHighlightJs)
+
 md.linkify
   .tlds(['onion', 'eth'], true)
   .add('bitcoin:', null)

--- a/yarn.lock
+++ b/yarn.lock
@@ -3615,6 +3615,11 @@ he@^1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
+highlight.js@^11.3.1:
+  version "11.4.0"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-11.4.0.tgz#34ceadd49e1596ee5aba3d99346cdfd4845ee05a"
+  integrity sha512-nawlpCBCSASs7EdvZOYOYVkJpGmAOKMYZgZtUqSRqodZE0GRVcFKwo1RcpeOemqh9hyttTdd5wDBwHkuSyUfnA==
+
 hpack.js@^2.1.6:
   version "2.1.6"
   resolved "https://registry.yarnpkg.com/hpack.js/-/hpack.js-2.1.6.tgz#87774c0949e513f42e84575b3c45681fade2a0b2"
@@ -4344,6 +4349,11 @@ lodash.flatten@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
   integrity sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=
 
+lodash.flow@^3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.flow/-/lodash.flow-3.5.0.tgz#87bf40292b8cf83e4e8ce1a3ae4209e20071675a"
+  integrity sha1-h79AKSuM+D5OjOGjrkIJ4gBxZ1o=
+
 lodash.isnull@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash.isnull/-/lodash.isnull-3.0.0.tgz#fafbe59ea1dca27eed786534039dd84c2e07c56e"
@@ -4454,6 +4464,14 @@ make-dir@^3.0.2, make-dir@^3.1.0:
   integrity sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==
   dependencies:
     semver "^6.0.0"
+
+markdown-it-highlightjs@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/markdown-it-highlightjs/-/markdown-it-highlightjs-3.6.0.tgz#b567408c633d71e5e4cc33e1d0121a44447d2f29"
+  integrity sha512-ex+Lq3cVkprh0GpGwFyc53A/rqY6GGzopPCG1xMsf8Ya3XtGC8Uw9tChN1rWbpyDae7tBBhVHVcMM29h4Btamw==
+  dependencies:
+    highlight.js "^11.3.1"
+    lodash.flow "^3.5.0"
 
 markdown-it@^12.3.0:
   version "12.3.0"


### PR DESCRIPTION

<img width="367" alt="image" src="https://user-images.githubusercontent.com/378886/150460959-2857a2e4-a817-48e8-bf3c-97c144418c0d.png">

<img width="712" alt="image" src="https://user-images.githubusercontent.com/378886/150461184-aa28ac95-3348-44b1-bda8-4231cc2e3fb8.png">

<img width="712" alt="image" src="https://user-images.githubusercontent.com/378886/150461218-0e391d3b-5b95-4c2d-947a-a7bd80d092f6.png">

`<<` was encoded into HTML entities by the `Markdown` component. Maybe because of `html` being turned off? Not sure.
<img width="712" alt="image" src="https://user-images.githubusercontent.com/378886/150461237-245f42bc-1648-40c7-82ff-fdec021580cc.png">

