### PR TITLE
Public relay name change

### DIFF
--- a/src/store/state.js
+++ b/src/store/state.js
@@ -15,7 +15,7 @@ const getMainnetRelays = () => {
     ['wss://nostr.onsats.org', '', ''],
     ['wss://nostr-relay.untethr.me', '', ''],
     ['wss://nostr-relay.wlvs.space', '', ''],
-    ['wss://nostr.bitcoiner.social', '', ''],
+    ['wss://offchain.pub', '', ''],
     ['wss://nostr.openchain.fr', '', ''],
     ['wss://nostr.drss.io', '', '']
   ]


### PR DESCRIPTION
nostr.bitcoiner.social -> offchain.pub

note1zpgy9f8tlwdwhhwtzy50vpl72qkunzhmy57p4f5xaf8h57pfvwpschwe74

> Before I deployed the new pay-to-relay server, I ran a public relay under a "nostr" subdomain. I've since renamed my public relay to wss://offchain.pub. Much cooler name. Better represents how nostr isn't something this domain handles on the side, it's the primary purpose. Raison d'etre.
> 
> Both offchain.pub and the "nostr" subdomain will work concurrently for awhile, pointing to the same public relay server. But I'll eventually deprecate the "nostr" subdomain and redirect requests to the new offchain.pub name.